### PR TITLE
Add PR template for course suggestions. 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+# Please include your course suggestions for future sessions
+
+New Course Suggestions format:
+
+- [ ] Your full name:
+
+- [ ] Your email:
+
+- [ ] Your TorontoJS Slack username:
+
+- [ ] Your discord username:
+
+- [ ] Today's date: YYYY-MM-DD
+  
+- [ ] Full Name of course:
+
+- [ ] Link to course: [course name](url)
+
+- [ ] Platform (eg Egghead, YouTube): [platform name](url)
+
+- [ ] Date the course was published: YYYY-MM-DD
+
+- [ ] Date the course was updated (if applicable): YYYY-MM-DD
+
+- [ ] Number of hours and minutes for course: HH hours, MM minutes
+
+- [ ] Is it free (it should be free!):
+
+- [ ] Why you're suggesting it:

--- a/Course Suggestion for Future.md
+++ b/Course Suggestion for Future.md
@@ -2,19 +2,6 @@
 
 **Do Not Edit This Section Please!**
 
-Suggestions format:
+Please do a pull request using the course suggestions PR template.
 
-- Your Name:
-- Your email:
-- The date that you are submitting your suggestion:
-- Name of course:
-- Link to course:
-- Platform (eg Egghead, YouTube):
-- Date the course was published:
-- Date the course was updated (if applicable):
-- Number of hours and minutes for course:
-- Is it free (it should be free!):
-- Why you're suggesting it:
-
-___
-### Put Your Suggestions Here
+**Add how to do a PR instructions here!**


### PR DESCRIPTION
Better to have a PR template for course suggestions than a never ending .md file.
We'll likely have to rename the template and add "how to do a PR" instructions in Course Suggestions for Future.md and add a link to that from README.md

Also updated Course Suggestions for Future.md to reflect that we have a pr template for that.